### PR TITLE
fix: add toolchain_bin_path to the path in inject_metadata_step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -591,6 +591,7 @@ pub fn addPebbleApplication(b: *std.Build, options: PebbleApplicationOptions) vo
 
         // Inject metadata into binary
         const inject_metadata_step = b.addSystemCommand(&.{ "uv", "tool", "run", "--from", "pebble-tool", "python", "-c", "import sys; import time; import shutil; from inject_metadata import inject_metadata; shutil.copy(sys.argv[1], sys.argv[4]); inject_metadata(sys.argv[4], sys.argv[2], sys.argv[3], int(time.time()))" });
+        inject_metadata_step.addPathDir(paths.toolchain_bin_path);
         inject_metadata_step.setEnvironmentVariable("PYTHONPATH", b.pathJoin(&.{ pebble_sdk_path, "sdk-core/pebble/common/tools" }));
         inject_metadata_step.addFileArg(raw_bin_file);
         inject_metadata_step.addFileArg(exe.getEmittedBin());


### PR DESCRIPTION
I was getting the following error in the `inject_metadata_step`. Looks like it just needed the toolchain_bin_path (~/.pebble-sdk/SDKs/current/toolchain/arm-none-eabi) added to the path for this step. Awesome project by the way. I planned on doing something like this myself, but it's cool to see a zig pebble sdk already exist :)

```
install
└─ run uv (watchface_example.pbw)
   └─ run uv (watchface_example.bin) failure
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; import time; import shutil; from inject_metadata import inject_metadata; shutil.copy(sys.argv[1], sys.argv[4]); inject_metadata(sys.argv[
4], sys.argv[2], sys.argv[3], int(time.time()))
                                                                                                                                ~~~~~~~~~~~~~~~^^^^^^^^^^
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mg/.pebble-sdk/SDKs/current/sdk-core/pebble/common/tools/inject_metadata.py", line 223, in inject_metadata
    nm_output = get_nm_output(target_elf)
  File "/home/mg/.pebble-sdk/SDKs/current/sdk-core/pebble/common/tools/inject_metadata.py", line 88, in get_nm_output
    nm_process = Popen(["arm-none-eabi-nm", elf_file], stdout=PIPE)
  File "/home/mg/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 1039, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mg/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 1991, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'arm-none-eabi-nm'
```