### PR TITLE
fix: place `.got` before `.bss` in the generated linker script

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -181,9 +181,10 @@ fn pebble_header_fixup(b: *std.Build, pebble_include_path: []const u8) []const u
 
 fn pebble_linker_script_template(b: *std.Build, pebble_linker_script_template_path: []const u8, platform: PebblePlatform) []const u8 {
     const linker_script = std.Io.Dir.cwd().readFileAlloc(b.graph.io, pebble_linker_script_template_path, b.allocator, .limited(1 << 20)) catch @panic("OOM");
+    const linker_script_with_got = std.mem.replaceOwned(u8, b.allocator, linker_script, "    .bss :", "    .got :\n    {\n        *(.got)\n        *(.got.*)\n    } > APP\n\n    .bss :") catch @panic("OOM");
 
     // Template max app memory size
-    return std.mem.replaceOwned(u8, b.allocator, linker_script, "@MAX_APP_MEMORY_SIZE@", b.fmt("0x{X}", .{PEBBLE_PLATFORMS.getAssertContains(platform).MAX_APP_MEMORY_SIZE})) catch @panic("OOM");
+    return std.mem.replaceOwned(u8, b.allocator, linker_script_with_got, "@MAX_APP_MEMORY_SIZE@", b.fmt("0x{X}", .{PEBBLE_PLATFORMS.getAssertContains(platform).MAX_APP_MEMORY_SIZE})) catch @panic("OOM");
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix issue where app builds cleanly but crashes at runtime. Bug can be reproduced by adding multiple `graphics_fill_rect` calls to a layer update proc.

## Context

The linker script template has no rule for `.got`, so LLD orphan-places it after `.bss`. `inject_metadata.py` computes `virtual_size` as the end of `.bss`, and the firmware starts the app heap at `app_base + virtual_size`, so the first heap allocation overwrites the GOT.

The fix adds an explicit `.got` section before `.bss`. We still name it `.got` (not merged into `.data`) as `inject_metadata.py` emits GOT relocation entries by looking for a section with that exact name, and without them the slot is never rebased.

Verified on the emery emulator: previously crashing app with multiple calls to `graphics_fill_rect` renders properly.